### PR TITLE
UI change to only track top item progress

### DIFF
--- a/src/main/java/com/brastasauce/purchaseprogress/PurchaseProgressConfig.java
+++ b/src/main/java/com/brastasauce/purchaseprogress/PurchaseProgressConfig.java
@@ -54,4 +54,15 @@ public interface PurchaseProgressConfig extends Config
 	{
 		return 0;
 	}
+
+	@ConfigItem(
+			keyName = "onlyTrackFirstItem",
+			name = "Only Track First Item",
+			description = "Only displays progress for the first listed item.",
+			position = 2
+	)
+	default boolean onlyTrackFirstItem()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/brastasauce/purchaseprogress/ui/PurchaseProgressGroupItemPanel.java
+++ b/src/main/java/com/brastasauce/purchaseprogress/ui/PurchaseProgressGroupItemPanel.java
@@ -24,6 +24,7 @@
  */
 package com.brastasauce.purchaseprogress.ui;
 
+import com.brastasauce.purchaseprogress.PurchaseProgressConfig;
 import com.brastasauce.purchaseprogress.PurchaseProgressPlugin;
 import com.brastasauce.purchaseprogress.data.PurchaseProgressGroup;
 import com.brastasauce.purchaseprogress.data.PurchaseProgressItem;
@@ -57,6 +58,8 @@ public class PurchaseProgressGroupItemPanel extends JPanel
     private static final ImageIcon SHIFT_DOWN_HOVER_ICON;
     private static final Dimension IMAGE_SIZE = new Dimension(32, 32);
 
+    private PurchaseProgressConfig config;
+
     private float percent;
     private int itemIndex;
 
@@ -75,8 +78,9 @@ public class PurchaseProgressGroupItemPanel extends JPanel
         SHIFT_DOWN_HOVER_ICON = new ImageIcon(ImageUtil.alphaOffset(shiftDownImage, 0.53f));
     }
 
-    PurchaseProgressGroupItemPanel(PurchaseProgressPlugin plugin, PurchaseProgressGroup group, PurchaseProgressItem item)
+    PurchaseProgressGroupItemPanel(PurchaseProgressPlugin plugin, PurchaseProgressGroup group, PurchaseProgressItem item, PurchaseProgressConfig config)
     {
+        this.config = config;
         setLayout(new BorderLayout(5, 0));
         setBorder(new EmptyBorder(5, 5, 5, 0));
 
@@ -124,7 +128,7 @@ public class PurchaseProgressGroupItemPanel extends JPanel
         {
             percent = 100;
         }
-        if (itemIndex == 0)
+        if (!config.onlyTrackFirstItem() || itemIndex == 0)
         {
             progressLabel.setText(String.format("%.0f", percent) + "%");
             rightPanel.add(progressLabel);
@@ -260,7 +264,7 @@ public class PurchaseProgressGroupItemPanel extends JPanel
     {
         int greenWidth = 0;
         g.setColor(new Color(12, 85, 35));
-        if(itemIndex == 0)
+        if(!config.onlyTrackFirstItem() || itemIndex == 0)
         {
             greenWidth = (int) (this.getWidth() * percent / 100);
         }

--- a/src/main/java/com/brastasauce/purchaseprogress/ui/PurchaseProgressGroupItemPanel.java
+++ b/src/main/java/com/brastasauce/purchaseprogress/ui/PurchaseProgressGroupItemPanel.java
@@ -58,6 +58,7 @@ public class PurchaseProgressGroupItemPanel extends JPanel
     private static final Dimension IMAGE_SIZE = new Dimension(32, 32);
 
     private float percent;
+    private int itemIndex;
 
     static
     {
@@ -79,7 +80,7 @@ public class PurchaseProgressGroupItemPanel extends JPanel
         setLayout(new BorderLayout(5, 0));
         setBorder(new EmptyBorder(5, 5, 5, 0));
 
-        int itemIndex = group.getItems().indexOf(item);
+        itemIndex = group.getItems().indexOf(item);
         int itemsSize = group.getItems().size();
 
         // Image
@@ -123,8 +124,11 @@ public class PurchaseProgressGroupItemPanel extends JPanel
         {
             percent = 100;
         }
-        progressLabel.setText(String.format("%.0f", percent) + "%");
-        rightPanel.add(progressLabel);
+        if (itemIndex == 0)
+        {
+            progressLabel.setText(String.format("%.0f", percent) + "%");
+            rightPanel.add(progressLabel);
+        }
 
         // Action Panel (Delete, Shift item)
         JPanel actionPanel = new JPanel(new BorderLayout());
@@ -254,8 +258,12 @@ public class PurchaseProgressGroupItemPanel extends JPanel
     @Override
     protected void paintComponent(Graphics g)
     {
+        int greenWidth = 0;
         g.setColor(new Color(12, 85, 35));
-        int greenWidth = (int) (this.getWidth() * percent / 100);
+        if(itemIndex == 0)
+        {
+            greenWidth = (int) (this.getWidth() * percent / 100);
+        }
         g.fillRect(0, 0, greenWidth, this.getHeight());
 
         if (greenWidth != this.getWidth())

--- a/src/main/java/com/brastasauce/purchaseprogress/ui/PurchaseProgressGroupPanel.java
+++ b/src/main/java/com/brastasauce/purchaseprogress/ui/PurchaseProgressGroupPanel.java
@@ -24,6 +24,7 @@
  */
 package com.brastasauce.purchaseprogress.ui;
 
+import com.brastasauce.purchaseprogress.PurchaseProgressConfig;
 import com.brastasauce.purchaseprogress.PurchaseProgressPlugin;
 import com.brastasauce.purchaseprogress.data.PurchaseProgressGroup;
 import com.brastasauce.purchaseprogress.data.PurchaseProgressItem;
@@ -86,7 +87,7 @@ public class PurchaseProgressGroupPanel extends JPanel
         UNCOLLAPSED_HOVER_ICON = new ImageIcon(ImageUtil.alphaOffset(uncollapsedImage, 0.53f));
     }
 
-    PurchaseProgressGroupPanel(PurchaseProgressPlugin plugin, PurchaseProgressPluginPanel panel, PurchaseProgressGroup group)
+    PurchaseProgressGroupPanel(PurchaseProgressPlugin plugin, PurchaseProgressPluginPanel panel, PurchaseProgressGroup group, PurchaseProgressConfig config)
     {
         setLayout(new BorderLayout(5, 0));
         setBorder(new EmptyBorder(5, 5, 5, 0));
@@ -313,7 +314,7 @@ public class PurchaseProgressGroupPanel extends JPanel
             int index = 0;
             for (PurchaseProgressItem item : group.getItems())
             {
-                PurchaseProgressGroupItemPanel itemPanel = new PurchaseProgressGroupItemPanel(plugin, group, item);
+                PurchaseProgressGroupItemPanel itemPanel = new PurchaseProgressGroupItemPanel(plugin, group, item, config);
 
                 if (index++ > 0)
                 {

--- a/src/main/java/com/brastasauce/purchaseprogress/ui/PurchaseProgressItemPanel.java
+++ b/src/main/java/com/brastasauce/purchaseprogress/ui/PurchaseProgressItemPanel.java
@@ -24,6 +24,7 @@
  */
 package com.brastasauce.purchaseprogress.ui;
 
+import com.brastasauce.purchaseprogress.PurchaseProgressConfig;
 import com.brastasauce.purchaseprogress.data.PurchaseProgressItem;
 import com.brastasauce.purchaseprogress.PurchaseProgressPlugin;
 import net.runelite.client.ui.ColorScheme;
@@ -56,6 +57,8 @@ public class PurchaseProgressItemPanel extends JPanel
     private static final ImageIcon SHIFT_DOWN_HOVER_ICON;
     private static final Dimension IMAGE_SIZE = new Dimension(32, 32);
 
+    private PurchaseProgressConfig config;
+
     private float percent;
     private int itemIndex;
 
@@ -74,8 +77,9 @@ public class PurchaseProgressItemPanel extends JPanel
         SHIFT_DOWN_HOVER_ICON = new ImageIcon(ImageUtil.alphaOffset(shiftDownImage, 0.53f));
     }
 
-    PurchaseProgressItemPanel(PurchaseProgressPlugin plugin, PurchaseProgressItem item)
+    PurchaseProgressItemPanel(PurchaseProgressPlugin plugin, PurchaseProgressItem item, PurchaseProgressConfig config)
     {
+        this.config = config;
         setLayout(new BorderLayout(5, 0));
         setBorder(new EmptyBorder(5, 5, 5, 0));
 
@@ -123,7 +127,7 @@ public class PurchaseProgressItemPanel extends JPanel
         {
             percent = 100;
         }
-        if (itemIndex == 0)
+        if (!config.onlyTrackFirstItem() || itemIndex == 0)
         {
             progressLabel.setText(String.format("%.0f", percent) + "%");
             rightPanel.add(progressLabel);
@@ -259,7 +263,7 @@ public class PurchaseProgressItemPanel extends JPanel
     {
         int greenWidth = 0;
         g.setColor(new Color(12, 85, 35));
-        if(itemIndex == 0)
+        if(!config.onlyTrackFirstItem() || itemIndex == 0)
         {
             greenWidth = (int) (this.getWidth() * percent / 100);
         }

--- a/src/main/java/com/brastasauce/purchaseprogress/ui/PurchaseProgressItemPanel.java
+++ b/src/main/java/com/brastasauce/purchaseprogress/ui/PurchaseProgressItemPanel.java
@@ -57,6 +57,7 @@ public class PurchaseProgressItemPanel extends JPanel
     private static final Dimension IMAGE_SIZE = new Dimension(32, 32);
 
     private float percent;
+    private int itemIndex;
 
     static
     {
@@ -78,7 +79,7 @@ public class PurchaseProgressItemPanel extends JPanel
         setLayout(new BorderLayout(5, 0));
         setBorder(new EmptyBorder(5, 5, 5, 0));
 
-        int itemIndex = plugin.getItems().indexOf(item);
+        itemIndex = plugin.getItems().indexOf(item);
         int itemsSize = plugin.getItems().size();
 
         // Image
@@ -122,8 +123,11 @@ public class PurchaseProgressItemPanel extends JPanel
         {
             percent = 100;
         }
-        progressLabel.setText(String.format("%.0f", percent) + "%");
-        rightPanel.add(progressLabel);
+        if (itemIndex == 0)
+        {
+            progressLabel.setText(String.format("%.0f", percent) + "%");
+            rightPanel.add(progressLabel);
+        }
 
         // Action Panel (Delete, Shift item)
         JPanel actionPanel = new JPanel(new BorderLayout());
@@ -245,7 +249,7 @@ public class PurchaseProgressItemPanel extends JPanel
     private boolean deleteConfirm()
     {
         int confirm = JOptionPane.showConfirmDialog(this,
-                        DELETE_MESSAGE, DELETE_TITLE, JOptionPane.YES_NO_OPTION);
+                DELETE_MESSAGE, DELETE_TITLE, JOptionPane.YES_NO_OPTION);
 
         return confirm == JOptionPane.YES_NO_OPTION;
     }
@@ -253,14 +257,19 @@ public class PurchaseProgressItemPanel extends JPanel
     @Override
     protected void paintComponent(Graphics g)
     {
+        int greenWidth = 0;
         g.setColor(new Color(12, 85, 35));
-        int greenWidth = (int) (this.getWidth() * percent / 100);
+        if(itemIndex == 0)
+        {
+            greenWidth = (int) (this.getWidth() * percent / 100);
+        }
         g.fillRect(0, 0, greenWidth, this.getHeight());
 
         if (greenWidth != this.getWidth())
         {
             g.setColor(ColorScheme.DARKER_GRAY_COLOR);
             g.fillRect(greenWidth, 0, this.getWidth() - greenWidth, this.getHeight());
+
         }
     }
 }

--- a/src/main/java/com/brastasauce/purchaseprogress/ui/PurchaseProgressPluginPanel.java
+++ b/src/main/java/com/brastasauce/purchaseprogress/ui/PurchaseProgressPluginPanel.java
@@ -24,6 +24,7 @@
  */
 package com.brastasauce.purchaseprogress.ui;
 
+import com.brastasauce.purchaseprogress.PurchaseProgressConfig;
 import com.brastasauce.purchaseprogress.data.PurchaseProgressGroup;
 import com.brastasauce.purchaseprogress.data.PurchaseProgressItem;
 import com.brastasauce.purchaseprogress.PurchaseProgressPlugin;
@@ -89,6 +90,7 @@ public class PurchaseProgressPluginPanel extends PluginPanel
     private final ClientThread clientThread;
     private final ItemManager itemManager;
     private final RuneLiteConfig runeLiteConfig;
+    private final PurchaseProgressConfig config;
 
     private final CardLayout centerCard = new CardLayout();
     private final CardLayout searchCard = new CardLayout();
@@ -133,13 +135,14 @@ public class PurchaseProgressPluginPanel extends PluginPanel
     }
 
     @Inject
-    PurchaseProgressPluginPanel(PurchaseProgressPlugin plugin, ClientThread clientThread, ItemManager itemManager, RuneLiteConfig runeLiteConfig)
+    PurchaseProgressPluginPanel(PurchaseProgressPlugin plugin, ClientThread clientThread, ItemManager itemManager, RuneLiteConfig runeLiteConfig, PurchaseProgressConfig config)
     {
         super(false);
         this.plugin = plugin;
         this.clientThread = clientThread;
         this.itemManager = itemManager;
         this.runeLiteConfig = runeLiteConfig;
+        this.config = config;
 
         setLayout(new BorderLayout());
 
@@ -454,7 +457,7 @@ public class PurchaseProgressPluginPanel extends PluginPanel
         // Groups
         for (PurchaseProgressGroup group : plugin.getGroups())
         {
-            PurchaseProgressGroupPanel panel = new PurchaseProgressGroupPanel(plugin, this, group);
+            PurchaseProgressGroupPanel panel = new PurchaseProgressGroupPanel(plugin, this, group, config);
 
             if (index++ > 0)
             {
@@ -472,7 +475,7 @@ public class PurchaseProgressPluginPanel extends PluginPanel
         // Individual items
         for (PurchaseProgressItem item : plugin.getItems())
         {
-            PurchaseProgressItemPanel panel = new PurchaseProgressItemPanel(plugin, item);
+            PurchaseProgressItemPanel panel = new PurchaseProgressItemPanel(plugin, item, config);
 
             if (index++ > 0)
             {


### PR DESCRIPTION
This is a UI change to only show the purchase percent and green progress bar for the top item of the general list or group. 
This is a design decision, not a strict improvement. However, I believe it makes the UI a bit more intuitive. Users can add items to the list then clear each one off as it is complete, and can view the grand total at the bottom. 